### PR TITLE
SWI-11188: fix YAML parse error in .bandwidth/component.yaml

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -3,7 +3,7 @@ kind: Component
 metadata:
   schemaVersion: v1.0.0
   name: node-mfa
-  description: Note: As of version 3.0.0, this package has been upgraded to TypeScript
+  description: "Note: As of version 3.0.0, this package has been upgraded to TypeScript"
   annotations:
     github.com/project-slug: Bandwidth/node-mfa
     organization: BW


### PR DESCRIPTION
The `description` value contains a colon which causes a YAML parse error, preventing this component from appearing in the Backstage catalog.

Fix: wrap the description value in double quotes.

Ref: SWI-11188